### PR TITLE
Removes TLS validation in favor of app transport security policy

### DIFF
--- a/Sources/Base/OAuth2AuthRequest.swift
+++ b/Sources/Base/OAuth2AuthRequest.swift
@@ -147,8 +147,9 @@ open class OAuth2AuthRequest {
 		guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
 				throw OAuth2Error.malformedURL(url)
 		}
-		guard "https" == components.scheme || ("http" == components.scheme && "localhost" == components.host) else {
-			throw OAuth2Error.notUsingTLS
+    // Validate scheme, but let app transport security policy enforce TLS:
+		guard components.scheme != nil, ["https", "http"].contains(components.scheme!.lowercased()) else {
+			throw OAuth2Error.invalidScheme
 		}
 		if .GET == method && params.count > 0 {
 			components.percentEncodedQuery = params.percentEncodedQueryString()

--- a/Sources/Base/OAuth2Error.swift
+++ b/Sources/Base/OAuth2Error.swift
@@ -88,7 +88,7 @@ public enum OAuth2Error: Error, CustomStringConvertible, Equatable {
 	// MARK: - Request errors
 	
 	/// The request is not using SSL/TLS.
-	case notUsingTLS
+	case invalidScheme
 	
 	/// Unable to open the authorize URL.
 	case unableToOpenAuthorizeURL
@@ -236,8 +236,8 @@ public enum OAuth2Error: Error, CustomStringConvertible, Equatable {
 		case .noRegistrationURL:
 			return "No registration URL defined"
 		
-		case .notUsingTLS:
-			return "You MUST use HTTPS/SSL/TLS"
+		case .invalidScheme:
+			return "You MUST use HTTP or HTTPS"
 		case .unableToOpenAuthorizeURL:
 			return "Cannot open authorize URL"
 		case .invalidRequest:
@@ -307,7 +307,7 @@ public enum OAuth2Error: Error, CustomStringConvertible, Equatable {
 		case (.noAccessToken, .noAccessToken):                       return true
 		case (.noRefreshToken, .noRefreshToken):                     return true
 		
-		case (.notUsingTLS, .notUsingTLS):                           return true
+		case (.invalidScheme, .invalidScheme):                           return true
 		case (.unableToOpenAuthorizeURL, .unableToOpenAuthorizeURL): return true
 		case (.invalidRequest, .invalidRequest):                     return true
 		case (.requestCancelled, .requestCancelled):                 return true


### PR DESCRIPTION
Connects to 4x4studios/lets-read-iOS#16